### PR TITLE
Add autoload map

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,10 @@
     "autoload": {
         "psr-4": {
             "CCFW\\": "./includes"
-        }
+        },
+        "classmap": [
+            "includes/"
+        ]
     },
     "authors": [{
         "name": "Minstry of Justice",


### PR DESCRIPTION
When Composer is run on dev or prod it is unable to find the correct
Class paths without this map.