### PR TITLE
Fix add_submenu_page() value wrong data type

### DIFF
--- a/cookie-compliance-for-wordpress.php
+++ b/cookie-compliance-for-wordpress.php
@@ -7,7 +7,7 @@
  * Plugin Name:       Cookie Compliance for WordPress
  * Plugin URI:        https://github.com/ministryofjustice/cookie-compliance-for-wordpress
  * Description:       Presents users with cookie compliance field when they first visit the website.
- * Version:           1.3.1
+ * Version:           1.3.2
  * Requires at least: 5.2.3
  * Requires PHP:      7.0
  * Author:            Ministry of Justice

--- a/includes/admin/admin.php
+++ b/includes/admin/admin.php
@@ -14,6 +14,7 @@ use \CCFW\Controller;
 
 class Admin extends Controller {
 
+
 	public function register() {
 		add_action( 'admin_menu', array( $this, 'add_admin_pages' ), 11 );
 	}
@@ -26,8 +27,6 @@ class Admin extends Controller {
 			'administrator',
 			'cookie_compliance',
 			array( $this, 'admin_index' ),
-			'
-		dashicons-welcome-view-site',
 			110
 		);
 	}


### PR DESCRIPTION
Icon string was in place where an init should be.