### PR TITLE
Fix save button and increase z-index on variant b cookie banner

### DIFF
--- a/includes/pub/partials/partial-banner.php
+++ b/includes/pub/partials/partial-banner.php
@@ -86,8 +86,8 @@ $domainName = str_replace('www.', '', $domainName);
                             </tr>
                             <tr class="govuk-table__row">
                             <th scope="row" class="govuk-table__header">_gat</th>
-                            <td class="govuk-table__cell">10 minutes</td>
                             <td class="govuk-table__cell">These help us to manage how we collect analytics when we have lots of visitors on the site at one time</td>
+                            <td class="govuk-table__cell">10 minutes</td>
                             </tr>
                         </tbody>
                         </table>

--- a/src/js/cookie-compliance-for-wordpress.js
+++ b/src/js/cookie-compliance-for-wordpress.js
@@ -161,7 +161,6 @@
           /* Based on Hidde de Vries' solution: https://hiddedevries.nl/en/blog/2017-01-29-using-javascript-to-trap-focus-in-an-element */
           let focusableEls = $('#ccfw-page-banner a[href], #ccfw-page-banner details, #ccfw-page-banner button, #ccfw-page-banner input[type="checkbox"]')
           let firstFocusableEl = focusableEls[0];
-          console.log(focusableEls)
           let lastFocusableEl = focusableEls[focusableEls.length - 1];
 
           this.$el.on('keydown', function (e) {
@@ -186,7 +185,7 @@
       },
       saveCookiePreferences: function () {
         let analyticsCookiesTurnedOn = this.$GAcheckbox.prop('checked')
-        console.log(analyticsCookiesTurnedOn)
+        utilities.setCookie(cookie_key_hide_banner, 'true', 365)
 
         if (analyticsCookiesTurnedOn === true) {
           googleAnalytics.googleSetDataLayer('on', 'on')
@@ -195,7 +194,6 @@
           googleAnalytics.googleSetDataLayer('off', 'off')
           googleAnalytics.googleSetCookie('revoke', 'revoke')
         }
-
         this.hideBanner()
       },
       hideBanner: function () {

--- a/src/scss/cookie-compliance-for-wordpress.scss
+++ b/src/scss/cookie-compliance-for-wordpress.scss
@@ -83,14 +83,14 @@ $breakpoints: ('small': (min-width: 767px),
     padding: 30px 10px 10px 10px;
     display: none;
     position: fixed;
-    z-index: 1;
+    z-index: 999;
     overflow-y: scroll;
 
      &.cookie-banner-open {
-        top: 0px;
-        left: 0px;
-        right: 0px;
-        bottom: 0px;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
     }
 }
 


### PR DESCRIPTION
The save button the cookie banner did set analytics cookies, but it didn't set the cookie to tell it to stop showing the banner. This fixes this bug. There is also an issue with some items with a high z-index on the site appearing on top of the cookie banner, so this increases the z-index to prevent this.