### PR TITLE
Google Analytics fix and refactor

### DIFF
--- a/dist/js/cookie-compliance-for-wordpress.js
+++ b/dist/js/cookie-compliance-for-wordpress.js
@@ -111,12 +111,13 @@
    * */
 
   $(function () {
-    var cookie_key_hide_banner = 'ccfw_wp_plugin.hide_banner';
+    var cookie_key_banner_hidden = 'ccfw_wp_plugin.banner.hidden';
     var cookie_key_ga_accept = 'ccfw_wp_plugin.ga.accept'; // This is used so much make sure all modules use it to save calls to DOM
 
-    var cacheMainElement = {
+    var cacheMainElements = {
       init: function init() {
         this.$el = $('#ccfw-page-banner');
+        this.$body = $('body');
       }
     };
     /**
@@ -128,7 +129,7 @@
         this.cacheDom();
       },
       cacheDom: function cacheDom() {
-        this.$el = cacheMainElement.$el;
+        this.$el = cacheMainElements.$el;
         this.$settingsModal = this.$el.find('#cookie-popup');
       },
       getCookie: function getCookie(name) {
@@ -173,30 +174,30 @@
         this.bannerDisplay();
       },
       cacheDom: function cacheDom() {
-        this.$el = cacheMainElement.$el;
-        this.$buttonaccept = this.$el.find('#cookie-accept');
-        this.$buttondecline = this.$el.find('#cookie-decline');
-        this.$buttoninfo = this.$el.find('#cookie-more-info');
+        this.$el = cacheMainElements.$el;
+        this.$buttonAccept = this.$el.find('#cookie-accept');
+        this.$buttonDecline = this.$el.find('#cookie-decline');
+        this.$buttonInfo = this.$el.find('#cookie-more-info');
       },
       bannerDisplay: function bannerDisplay() {
-        if (utilities.checkForCookie(cookie_key_hide_banner) === true) {
+        if (utilities.checkForCookie(cookie_key_banner_hidden) === true) {
           utilities.hideBanner();
         } else {
           this.$el.show();
         }
       },
       bindEvents: function bindEvents() {
-        this.$buttonaccept.on('click', this.acceptAllButton.bind(this));
-        this.$buttondecline.on('click', this.declineAllButton.bind(this));
-        this.$buttoninfo.on('click', this.chooseCookieSettingsButton.bind(this));
+        this.$buttonAccept.on('click', this.acceptAllButton.bind(this));
+        this.$buttonDecline.on('click', this.declineAllButton.bind(this));
+        this.$buttonInfo.on('click', this.chooseCookieSettingsButton.bind(this));
       },
       acceptAllButton: function acceptAllButton() {
-        utilities.setCookie(cookie_key_hide_banner, 'true', 365);
+        utilities.setCookie(cookie_key_banner_hidden, 'true', 365);
         utilities.setCookie(cookie_key_ga_accept, 'true', 365);
         utilities.hideBanner();
       },
       declineAllButton: function declineAllButton() {
-        utilities.setCookie(cookie_key_hide_banner, 'true', 365); // GA - If present remove GA cookie, otherwise do nothing, default is GA off
+        utilities.setCookie(cookie_key_banner_hidden, 'true', 365); // GA - If present remove GA cookie, otherwise do nothing, default is GA off
 
         if (utilities.checkForCookie(cookie_key_ga_accept)) {
           utilities.deleteCookie(cookie_key_ga_accept);
@@ -214,28 +215,28 @@
         this.bindEvents();
       },
       cacheDom: function cacheDom() {
-        this.$el = cacheMainElement.$el;
+        this.$el = cacheMainElements.$el;
         this.$settingsModal = this.$el.find('#cookie-popup');
-        this.$buttonaccept = this.$settingsModal.find('#cookie-accept');
-        this.$buttondecline = this.$settingsModal.find('#cookie-decline');
-        this.$buttoninfo = this.$settingsModal.find('#cookie-more-info');
-        this.$buttonsavepreferences = this.$settingsModal.find('#cookie-save-preferences');
-        this.$GAcheckbox = this.$settingsModal.find('#ccfw-ga-toggle');
-        this.$buttonmodalclose = this.$settingsModal.find('#ccfw-modal-close');
-        this.$body = $('body');
+        this.$buttonAccept = this.$settingsModal.find('#cookie-accept');
+        this.$buttonDecline = this.$settingsModal.find('#cookie-decline');
+        this.$buttonInfo = this.$settingsModal.find('#cookie-more-info');
+        this.$buttonSavePreferences = this.$settingsModal.find('#cookie-save-preferences');
+        this.$GAcheckBox = this.$settingsModal.find('#ccfw-ga-toggle');
+        this.$buttonModalClose = this.$settingsModal.find('#ccfw-modal-close');
+        this.$body = cacheMainElements.$body;
       },
       bindEvents: function bindEvents() {
-        this.$buttoninfo.on('click', this.viewMoreInfo.bind(this));
-        this.$buttonsavepreferences.on('click', this.saveCookiePreferences.bind(this));
-        this.$buttonmodalclose.on('click', this.modalDisplay.bind(this));
+        this.$buttonModalClose.on('click', this.modalDisplay.bind(this));
+        this.$buttonInfo.on('click', this.viewMoreInfo.bind(this));
+        this.$buttonSavePreferences.on('click', this.saveCookiePreferences.bind(this));
       },
       modalDisplay: function modalDisplay() {
         utilities.hideSettingsModal();
       },
       viewMoreInfo: function viewMoreInfo() {
-        this.$buttoninfo.attr('aria-expanded', 'true');
-        utilities.showSettingsModal();
+        this.$buttonInfo.attr('aria-expanded', 'true');
         this.$body.addClass("ccfw-modal-open");
+        utilities.showSettingsModal();
         /*Trap focus */
 
         /* Based on Hidde de Vries' solution: https://hiddedevries.nl/en/blog/2017-01-29-using-javascript-to-trap-focus-in-an-element */
@@ -266,7 +267,7 @@
         });
       },
       saveCookiePreferences: function saveCookiePreferences() {
-        var analyticsCookiesTurnedOn = this.$GAcheckbox.prop('checked');
+        var analyticsCookiesTurnedOn = this.$GAcheckBox.prop('checked');
 
         if (analyticsCookiesTurnedOn === true) {
           utilities.setCookie(cookie_key_ga_accept, 'true', 365);
@@ -279,12 +280,12 @@
           }
         }
 
-        utilities.setCookie(cookie_key_hide_banner, 'true', 365);
+        utilities.setCookie(cookie_key_banner_hidden, 'true', 365);
         utilities.hideBanner();
         utilities.hideSettingsModal();
       }
     };
-    cacheMainElement.init();
+    cacheMainElements.init();
     utilities.init();
     banner.init();
     settingsModal.init();

--- a/dist/js/cookie-compliance-for-wordpress.js
+++ b/dist/js/cookie-compliance-for-wordpress.js
@@ -112,8 +112,8 @@
 
   $(function () {
     var cookie_key_hide_banner = 'ccfw_wp_plugin.hide_banner';
-    var cookie_key_ga = 'ccfw_wp_plugin.ga';
-    var cookie_key_gtm = 'ccfw_wp_plugin.gtm';
+    var cookie_key_ga_accept = 'ccfw_wp_plugin.ga.accept';
+    var cookie_key_ga_reject = 'ccfw_wp_plugin.ga.reject';
     /**
     *  Helper functions for shared tasks
     * */
@@ -133,6 +133,11 @@
         d.setTime(d.getTime() + 24 * 60 * 60 * 1000 * days);
         document.cookie = name + '=' + value + '; path=/; expires=' + d.toGMTString();
       },
+      deleteCookie: function deleteCookie(name) {
+        var d = new Date();
+        d.setTime(d.getTime() + 24 * 60 * 60 * 1000 * 365);
+        document.cookie = name + '=; Path=/; expires=' + d.toGMTString();
+      },
       checkForCookie: function checkForCookie(key) {
         var cookie = this.getCookie(key);
 
@@ -143,59 +148,6 @@
         }
 
         return bool;
-      }
-    };
-    /**
-     *  Module to interact with Google Data Layer and setting Google cookie config
-     *
-     * */
-
-    var googleAnalytics = {
-      init: function init() {},
-      googleSetDataLayer: function googleSetDataLayer(analytics, tagManager) {
-        // Google Analytics value on or off
-        if (analytics === 'on') {
-          var boolGA = false;
-        } else if (analytics === 'off') {
-          var boolGA = true;
-        } // Google Tag Manager value on or off
-
-
-        if (tagManager === 'on') {
-          var boolGTM = false;
-        } else if (tagManager === 'off') {
-          var boolGTM = true;
-        }
-
-        if (typeof ga === 'function') {
-          ga(function () {
-            // ga() function loads last, retrieve GA and GTM ID numbers
-            var GA_ID = Object.keys(gaData)[0];
-            var GTM_ID = Object.keys(google_tag_manager)[0];
-            window['ga-disable-' + GA_ID] = boolGA;
-            window['ga-disable-' + GTM_ID] = boolGTM;
-          });
-        }
-      },
-      googleSetCookie: function googleSetCookie(analytics, tagManager) {
-        utilities.setCookie(cookie_key_ga, analytics, 365);
-        utilities.setCookie(cookie_key_gtm, tagManager, 365);
-      }
-    };
-    /**
-     *  Opt-out by default of all analytics/trackers
-     *  on page load or first visit
-     * */
-
-    var optOutByDefault = {
-      init: function init() {
-        this.loadGA();
-      },
-      loadGA: function loadGA() {
-        if (utilities.getCookie(cookie_key_hide_banner) != 'true') {
-          googleAnalytics.googleSetDataLayer('off', 'off');
-          googleAnalytics.googleSetCookie('revoke', 'revoke');
-        }
       }
     };
     /**
@@ -215,14 +167,12 @@
         this.$buttondecline = this.$el.find('#cookie-decline');
         this.$buttoninfo = this.$el.find('#cookie-more-info');
         this.$buttonsavepreferences = this.$el.find('#cookie-save-preferences');
-        this.$GAcheckbox = this.$el.find('#ccfw-ga-checkbox');
+        this.$GAcheckbox = this.$el.find('#ccfw-ga-toggle');
         this.$buttonmodalclose = this.$el.find('#ccfw-modal-close');
         this.$body = $('body');
       },
       setBannerDisplay: function setBannerDisplay() {
-        var cookieExists = utilities.checkForCookie(cookie_key_hide_banner);
-
-        if (cookieExists === true) {
+        if (utilities.checkForCookie(cookie_key_hide_banner) === true) {
           this.$el.hide();
         } else {
           this.$el.show();
@@ -237,14 +187,12 @@
       },
       acceptAllButton: function acceptAllButton() {
         utilities.setCookie(cookie_key_hide_banner, 'true', 365);
-        googleAnalytics.googleSetDataLayer('on', 'on');
-        googleAnalytics.googleSetCookie('accept', 'accept');
+        utilities.setCookie(cookie_key_ga_accept, 'true', 365);
         this.hideBanner();
       },
       declineAllButton: function declineAllButton() {
         utilities.setCookie(cookie_key_hide_banner, 'true', 365);
-        googleAnalytics.googleSetDataLayer('off', 'off');
-        googleAnalytics.googleSetCookie('revoke', 'revoke');
+        utilities.setCookie(cookie_key_ga_reject, 'true', 365);
         this.hideBanner();
       },
       viewMoreInfo: function viewMoreInfo() {
@@ -291,14 +239,15 @@
       },
       saveCookiePreferences: function saveCookiePreferences() {
         var analyticsCookiesTurnedOn = this.$GAcheckbox.prop('checked');
+        console.log(analyticsCookiesTurnedOn);
         utilities.setCookie(cookie_key_hide_banner, 'true', 365);
 
         if (analyticsCookiesTurnedOn === true) {
-          googleAnalytics.googleSetDataLayer('on', 'on');
-          googleAnalytics.googleSetCookie('accept', 'accept');
-        } else {
-          googleAnalytics.googleSetDataLayer('off', 'off');
-          googleAnalytics.googleSetCookie('revoke', 'revoke');
+          utilities.setCookie(cookie_key_ga_accept, 'true', 365);
+        }
+
+        if (analyticsCookiesTurnedOn === false) {
+          utilities.setCookie(cookie_key_ga_reject, 'true', 365);
         }
 
         this.closeModal();
@@ -309,65 +258,8 @@
         this.$el.removeClass("cookie-banner-open");
       }
     };
-    /**
-     *  Settings page where a user toggles tracking on/off
-     * */
-
-    var settingsPage = {
-      init: function init() {
-        this.cacheDom();
-        this.bindEvents();
-        this.setPrevLink();
-      },
-      cacheDom: function cacheDom() {
-        this.$el = $('#ccfw-settings-page-container');
-        this.$googleYes = this.$el.find('#ga-yes');
-        this.$googleNo = this.$el.find('#ga-no');
-        this.$saveBtn = this.$el.find('#save-changes-btn');
-        this.$saveNoticeBanner = this.$el.find('#save-notice');
-        this.$prevLink = this.$el.find('#prev-link');
-      },
-      setPrevLink: function setPrevLink() {
-        var referrer = document.referrer;
-
-        if (referrer.length > 0) {
-          this.$prevLink.attr('href', referrer);
-        }
-      },
-      bindEvents: function bindEvents() {
-        this.$saveBtn.on('click', this.saveSettings.bind(this));
-      },
-      saveSettings: function saveSettings() {
-        /**
-        *  Right now there is no distinction between
-        *  GA and GTM both Google trackers here are checked on or off together.
-        *  In the future we may want to refactor to check each individually.
-        * */
-        var googleButtonYes = this.$googleYes.prop('checked');
-        var googleButtonNo = this.$googleNo.prop('checked');
-
-        if (googleButtonYes === true) {
-          googleAnalytics.googleSetDataLayer('on', 'on');
-          googleAnalytics.googleSetCookie('accept', 'accept');
-        } else if (googleButtonNo === true) {
-          googleAnalytics.googleSetDataLayer('off', 'off');
-          googleAnalytics.googleSetCookie('revoke', 'revoke');
-        }
-
-        utilities.setCookie(cookie_key_hide_banner, 'true', 365);
-        this.displayNoticeBanner();
-      },
-      displayNoticeBanner: function displayNoticeBanner() {
-        this.$saveNoticeBanner.show();
-        $(document).scrollTop(this.$saveNoticeBanner.offset().top);
-        this.$saveNoticeBanner.focus();
-      }
-    };
     utilities.init();
-    googleAnalytics.init();
-    optOutByDefault.init();
     banner.init();
-    settingsPage.init();
   });
 })(jQuery);
 

--- a/includes/pub/pub.php
+++ b/includes/pub/pub.php
@@ -27,18 +27,19 @@ class Pub extends Controller
 
     public function register()
     {
+        add_action('wp_head', array( $this, 'disable_google_analytics_on_load' ), 11);
         add_action('wp_body_open', array( $this, 'cookie_compliance_banner' ), 11);
-        add_action('wp_head', array( $this, 'turnOffGA' ), 11);
         add_action('query_vars', array( $this, 'ccfw_query_vars' ), 11);
         add_action('parse_request', array( $this, 'cookie_compliance_pages' ), 11);
         add_action('init', array( $this, 'ccfw_rewrite_rule' ), 11, 0);
     }
 
-    public function turnOffGA() {
+    public function disable_google_analytics_on_load() {
+        // If cookie "ccfw_wp_plugin.ga.accept" not present, disable GA
         ?>
         <script>
-            var cookieSet = document.cookie.indexOf('ccfw_wp_plugin.ga=') == -1 ? true : false;
-            window['ga-disable-UA-174461977-1'] = cookieSet;
+            var ccfwPluginGACookieNotPresent = document.cookie.indexOf('ccfw_wp_plugin.ga.accept=') == -1 ? true : false;
+            window['ga-disable-UA-174461977-1'] = ccfwPluginGACookieNotPresent;
         </script>
         <?php
     }

--- a/includes/pub/pub.php
+++ b/includes/pub/pub.php
@@ -28,9 +28,19 @@ class Pub extends Controller
     public function register()
     {
         add_action('wp_body_open', array( $this, 'cookie_compliance_banner' ), 11);
+        add_action('wp_head', array( $this, 'turnOffGA' ), 11);
         add_action('query_vars', array( $this, 'ccfw_query_vars' ), 11);
         add_action('parse_request', array( $this, 'cookie_compliance_pages' ), 11);
         add_action('init', array( $this, 'ccfw_rewrite_rule' ), 11, 0);
+    }
+
+    public function turnOffGA() {
+        ?>
+        <script>
+            var cookieSet = document.cookie.indexOf('ccfw_wp_plugin.ga=') == -1 ? true : false;
+            window['ga-disable-UA-174461977-1'] = cookieSet;
+        </script>
+        <?php
     }
 
     public function cookie_compliance_banner()

--- a/src/js/cookie-compliance-for-wordpress.js
+++ b/src/js/cookie-compliance-for-wordpress.js
@@ -16,8 +16,8 @@
   $(function () {
 
     const cookie_key_hide_banner = 'ccfw_wp_plugin.hide_banner'
-    const cookie_key_ga          = 'ccfw_wp_plugin.ga'
-    const cookie_key_gtm         = 'ccfw_wp_plugin.gtm'
+    const cookie_key_ga_accept   = 'ccfw_wp_plugin.ga.accept'
+    const cookie_key_ga_reject   = 'ccfw_wp_plugin.ga.reject'
 
    /**
    *  Helper functions for shared tasks
@@ -36,6 +36,11 @@
         d.setTime(d.getTime() + 24 * 60 * 60 * 1000 * days)
         document.cookie = name + '=' + value + '; path=/; expires=' + d.toGMTString()
       },
+      deleteCookie: function (name) {
+        var d = new Date()
+        d.setTime(d.getTime() + 24 * 60 * 60 * 1000 * 365)
+        document.cookie = name +'=; Path=/; expires=' + d.toGMTString()
+      },
       checkForCookie: function (key) {
         let cookie = this.getCookie(key)
         if (cookie === undefined) {
@@ -44,61 +49,6 @@
           var bool = true
         }
         return bool
-      }
-    }
-
-    /**
-     *  Module to interact with Google Data Layer and setting Google cookie config
-     *
-     * */
-    const googleAnalytics = {
-      init: function () {},
-      googleSetDataLayer: function (analytics,tagManager) {
-
-        // Google Analytics value on or off
-        if (analytics === 'on') {
-          var boolGA = false
-        } else if (analytics === 'off') {
-          var boolGA = true
-        }
-
-        // Google Tag Manager value on or off
-        if (tagManager === 'on') {
-          var boolGTM = false
-        } else if (tagManager === 'off') {
-          var boolGTM = true
-        }
-
-        if (typeof ga === 'function') {
-          ga(() => {
-            // ga() function loads last, retrieve GA and GTM ID numbers
-            var GA_ID = Object.keys(gaData)[0]
-            var GTM_ID = Object.keys(google_tag_manager)[0]
-
-            window['ga-disable-' + GA_ID] = boolGA
-            window['ga-disable-' + GTM_ID] = boolGTM
-          })
-        }
-      },
-      googleSetCookie: function (analytics,tagManager) {
-        utilities.setCookie(cookie_key_ga, analytics, 365)
-        utilities.setCookie(cookie_key_gtm, tagManager, 365)
-      }
-     }
-
-    /**
-     *  Opt-out by default of all analytics/trackers
-     *  on page load or first visit
-     * */
-    const optOutByDefault = {
-      init: function () {
-        this.loadGA()
-      },
-      loadGA: function () {
-        if (utilities.getCookie(cookie_key_hide_banner) != 'true'){
-          googleAnalytics.googleSetDataLayer('off', 'off')
-          googleAnalytics.googleSetCookie('revoke', 'revoke')
-        }
       }
     }
 
@@ -118,13 +68,12 @@
         this.$buttondecline = this.$el.find('#cookie-decline')
         this.$buttoninfo = this.$el.find('#cookie-more-info')
         this.$buttonsavepreferences = this.$el.find('#cookie-save-preferences')
-        this.$GAcheckbox = this.$el.find('#ccfw-ga-checkbox')
+        this.$GAcheckbox = this.$el.find('#ccfw-ga-toggle')
         this.$buttonmodalclose = this.$el.find('#ccfw-modal-close')
         this.$body = $('body')
       },
       setBannerDisplay: function () {
-        let cookieExists = utilities.checkForCookie(cookie_key_hide_banner)
-        if (cookieExists === true) {
+        if (utilities.checkForCookie(cookie_key_hide_banner) === true) {
           this.$el.hide()
         } else {
           this.$el.show()
@@ -139,14 +88,12 @@
       },
       acceptAllButton: function () {
         utilities.setCookie(cookie_key_hide_banner, 'true', 365)
-        googleAnalytics.googleSetDataLayer('on', 'on')
-        googleAnalytics.googleSetCookie('accept', 'accept')
+        utilities.setCookie(cookie_key_ga_accept, 'true', 365)
         this.hideBanner()
       },
       declineAllButton: function() {
         utilities.setCookie(cookie_key_hide_banner, 'true', 365)
-        googleAnalytics.googleSetDataLayer('off', 'off')
-        googleAnalytics.googleSetCookie('revoke', 'revoke')
+        utilities.setCookie(cookie_key_ga_reject, 'true', 365)
         this.hideBanner()
       },
       viewMoreInfo: function () {
@@ -189,15 +136,19 @@
       },
       saveCookiePreferences: function () {
         let analyticsCookiesTurnedOn = this.$GAcheckbox.prop('checked')
+
+        console.log(analyticsCookiesTurnedOn)
+
         utilities.setCookie(cookie_key_hide_banner, 'true', 365)
 
         if (analyticsCookiesTurnedOn === true) {
-          googleAnalytics.googleSetDataLayer('on', 'on')
-          googleAnalytics.googleSetCookie('accept', 'accept')
-        } else {
-          googleAnalytics.googleSetDataLayer('off', 'off')
-          googleAnalytics.googleSetCookie('revoke', 'revoke')
+          utilities.setCookie(cookie_key_ga_accept, 'true', 365)
         }
+
+        if (analyticsCookiesTurnedOn === false) {
+          utilities.setCookie(cookie_key_ga_reject, 'true', 365)
+        }
+
         this.closeModal()
         this.hideBanner()
       },
@@ -207,63 +158,7 @@
       }
     }
 
-    /**
-     *  Settings page where a user toggles tracking on/off
-     * */
-    const settingsPage = {
-      init: function () {
-          this.cacheDom()
-          this.bindEvents()
-          this.setPrevLink()
-      },
-      cacheDom: function () {
-        this.$el = $('#ccfw-settings-page-container')
-        this.$googleYes = this.$el.find('#ga-yes')
-        this.$googleNo = this.$el.find('#ga-no')
-        this.$saveBtn = this.$el.find('#save-changes-btn')
-        this.$saveNoticeBanner = this.$el.find('#save-notice')
-        this.$prevLink = this.$el.find('#prev-link')
-      },
-      setPrevLink: function () {
-        let referrer = document.referrer
-        if (referrer.length > 0) {
-          this.$prevLink.attr('href', referrer)
-        }
-      },
-      bindEvents: function () {
-        this.$saveBtn.on('click', this.saveSettings.bind(this))
-      },
-      saveSettings: function () {
-        /**
-       *  Right now there is no distinction between
-       *  GA and GTM both Google trackers here are checked on or off together.
-       *  In the future we may want to refactor to check each individually.
-       * */
-        const googleButtonYes = this.$googleYes.prop('checked')
-        const googleButtonNo = this.$googleNo.prop('checked')
-
-        if (googleButtonYes === true) {
-          googleAnalytics.googleSetDataLayer('on', 'on')
-          googleAnalytics.googleSetCookie('accept', 'accept')
-        } else if (googleButtonNo === true) {
-          googleAnalytics.googleSetDataLayer('off', 'off')
-          googleAnalytics.googleSetCookie('revoke', 'revoke')
-        }
-
-        utilities.setCookie(cookie_key_hide_banner, 'true', 365)
-        this.displayNoticeBanner()
-      },
-      displayNoticeBanner: function () {
-        this.$saveNoticeBanner.show()
-        $(document).scrollTop(this.$saveNoticeBanner.offset().top)
-        this.$saveNoticeBanner.focus()
-      }
-    }
-
     utilities.init()
-    googleAnalytics.init()
-    optOutByDefault.init()
     banner.init()
-    settingsPage.init()
   })
 })(jQuery)

--- a/src/js/cookie-compliance-for-wordpress.js
+++ b/src/js/cookie-compliance-for-wordpress.js
@@ -15,13 +15,14 @@
    * */
   $(function () {
 
-    const cookie_key_hide_banner = 'ccfw_wp_plugin.hide_banner'
+    const cookie_key_banner_hidden = 'ccfw_wp_plugin.banner.hidden'
     const cookie_key_ga_accept   = 'ccfw_wp_plugin.ga.accept'
 
     // This is used so much make sure all modules use it to save calls to DOM
-    const cacheMainElement = {
+    const cacheMainElements = {
       init: function () {
         this.$el = $('#ccfw-page-banner')
+        this.$body = $('body')
       }
     }
 
@@ -33,7 +34,7 @@
         this.cacheDom()
       },
       cacheDom: function () {
-        this.$el = cacheMainElement.$el
+        this.$el = cacheMainElements.$el
         this.$settingsModal = this.$el.find('#cookie-popup')
       },
       getCookie: function (name) {
@@ -77,30 +78,30 @@
         this.bannerDisplay()
       },
       cacheDom: function () {
-        this.$el = cacheMainElement.$el
-        this.$buttonaccept = this.$el.find('#cookie-accept')
-        this.$buttondecline = this.$el.find('#cookie-decline')
-        this.$buttoninfo = this.$el.find('#cookie-more-info')
+        this.$el = cacheMainElements.$el
+        this.$buttonAccept = this.$el.find('#cookie-accept')
+        this.$buttonDecline = this.$el.find('#cookie-decline')
+        this.$buttonInfo = this.$el.find('#cookie-more-info')
       },
       bannerDisplay: function () {
-        if (utilities.checkForCookie(cookie_key_hide_banner) === true) {
+        if (utilities.checkForCookie(cookie_key_banner_hidden) === true) {
           utilities.hideBanner()
         } else {
           this.$el.show()
         }
       },
       bindEvents: function () {
-        this.$buttonaccept.on('click', this.acceptAllButton.bind(this))
-        this.$buttondecline.on('click', this.declineAllButton.bind(this))
-        this.$buttoninfo.on('click', this.chooseCookieSettingsButton.bind(this))
+        this.$buttonAccept.on('click', this.acceptAllButton.bind(this))
+        this.$buttonDecline.on('click', this.declineAllButton.bind(this))
+        this.$buttonInfo.on('click', this.chooseCookieSettingsButton.bind(this))
       },
       acceptAllButton: function () {
-        utilities.setCookie(cookie_key_hide_banner, 'true', 365)
+        utilities.setCookie(cookie_key_banner_hidden, 'true', 365)
         utilities.setCookie(cookie_key_ga_accept, 'true', 365)
         utilities.hideBanner()
       },
       declineAllButton: function() {
-        utilities.setCookie(cookie_key_hide_banner, 'true', 365)
+        utilities.setCookie(cookie_key_banner_hidden, 'true', 365)
 
         // GA - If present remove GA cookie, otherwise do nothing, default is GA off
         if (utilities.checkForCookie(cookie_key_ga_accept)) {
@@ -119,28 +120,28 @@
         this.bindEvents()
       },
       cacheDom: function () {
-        this.$el = cacheMainElement.$el
+        this.$el = cacheMainElements.$el
         this.$settingsModal = this.$el.find('#cookie-popup')
-        this.$buttonaccept = this.$settingsModal.find('#cookie-accept')
-        this.$buttondecline = this.$settingsModal.find('#cookie-decline')
-        this.$buttoninfo = this.$settingsModal.find('#cookie-more-info')
-        this.$buttonsavepreferences = this.$settingsModal.find('#cookie-save-preferences')
-        this.$GAcheckbox = this.$settingsModal.find('#ccfw-ga-toggle')
-        this.$buttonmodalclose = this.$settingsModal.find('#ccfw-modal-close')
-        this.$body = $('body')
+        this.$buttonAccept = this.$settingsModal.find('#cookie-accept')
+        this.$buttonDecline = this.$settingsModal.find('#cookie-decline')
+        this.$buttonInfo = this.$settingsModal.find('#cookie-more-info')
+        this.$buttonSavePreferences = this.$settingsModal.find('#cookie-save-preferences')
+        this.$GAcheckBox = this.$settingsModal.find('#ccfw-ga-toggle')
+        this.$buttonModalClose = this.$settingsModal.find('#ccfw-modal-close')
+        this.$body = cacheMainElements.$body
       },
       bindEvents: function () {
-        this.$buttoninfo.on('click', this.viewMoreInfo.bind(this))
-        this.$buttonsavepreferences.on('click', this.saveCookiePreferences.bind(this))
-        this.$buttonmodalclose.on('click', this.modalDisplay.bind(this))
+        this.$buttonModalClose.on('click', this.modalDisplay.bind(this))
+        this.$buttonInfo.on('click', this.viewMoreInfo.bind(this))
+        this.$buttonSavePreferences.on('click', this.saveCookiePreferences.bind(this))
       },
       modalDisplay: function () {
         utilities.hideSettingsModal()
       },
       viewMoreInfo: function () {
-        this.$buttoninfo.attr('aria-expanded', 'true')
-        utilities.showSettingsModal()
+        this.$buttonInfo.attr('aria-expanded', 'true')
         this.$body.addClass("ccfw-modal-open")
+        utilities.showSettingsModal()
 
         /*Trap focus */
         /* Based on Hidde de Vries' solution: https://hiddedevries.nl/en/blog/2017-01-29-using-javascript-to-trap-focus-in-an-element */
@@ -167,7 +168,7 @@
         })
       },
       saveCookiePreferences: function () {
-        let analyticsCookiesTurnedOn = this.$GAcheckbox.prop('checked')
+        let analyticsCookiesTurnedOn = this.$GAcheckBox.prop('checked')
 
         if (analyticsCookiesTurnedOn === true) {
           utilities.setCookie(cookie_key_ga_accept, 'true', 365)
@@ -180,13 +181,13 @@
           }
         }
 
-        utilities.setCookie(cookie_key_hide_banner, 'true', 365)
+        utilities.setCookie(cookie_key_banner_hidden, 'true', 365)
         utilities.hideBanner()
         utilities.hideSettingsModal()
       },
     }
 
-    cacheMainElement.init()
+    cacheMainElements.init()
     utilities.init()
     banner.init()
     settingsModal.init()

--- a/src/js/cookie-compliance-for-wordpress.js
+++ b/src/js/cookie-compliance-for-wordpress.js
@@ -17,13 +17,25 @@
 
     const cookie_key_hide_banner = 'ccfw_wp_plugin.hide_banner'
     const cookie_key_ga_accept   = 'ccfw_wp_plugin.ga.accept'
-    const cookie_key_ga_reject   = 'ccfw_wp_plugin.ga.reject'
+
+    // This is used so much make sure all modules use it to save calls to DOM
+    const cacheMainElement = {
+      init: function () {
+        this.$el = $('#ccfw-page-banner')
+      }
+    }
 
    /**
    *  Helper functions for shared tasks
    * */
     const utilities = {
-      init: function () {},
+      init: function () {
+        this.cacheDom()
+      },
+      cacheDom: function () {
+        this.$el = cacheMainElement.$el
+        this.$settingsModal = this.$el.find('#cookie-popup')
+      },
       getCookie: function (name) {
         var value = '; ' + document.cookie
         var parts = value.split('; ' + name + '=')
@@ -37,18 +49,21 @@
         document.cookie = name + '=' + value + '; path=/; expires=' + d.toGMTString()
       },
       deleteCookie: function (name) {
-        var d = new Date()
-        d.setTime(d.getTime() + 24 * 60 * 60 * 1000 * 365)
-        document.cookie = name +'=; Path=/; expires=' + d.toGMTString()
+        document.cookie = name +'=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
       },
       checkForCookie: function (key) {
         let cookie = this.getCookie(key)
-        if (cookie === undefined) {
-          var bool = false
-        } else {
-          var bool = true
-        }
+        let bool = cookie === undefined ? false : true
         return bool
+      },
+      hideBanner: function () {
+        this.$el.hide()
+      },
+      hideSettingsModal: function () {
+        this.$settingsModal.hide()
+      },
+      showSettingsModal: function () {
+        this.$settingsModal.show()
       }
     }
 
@@ -59,22 +74,17 @@
       init: function () {
         this.cacheDom()
         this.bindEvents()
-        this.setBannerDisplay()
+        this.bannerDisplay()
       },
       cacheDom: function () {
-        this.$el = $('#ccfw-page-banner')
-        this.$popup = $('#cookie-popup')
+        this.$el = cacheMainElement.$el
         this.$buttonaccept = this.$el.find('#cookie-accept')
         this.$buttondecline = this.$el.find('#cookie-decline')
         this.$buttoninfo = this.$el.find('#cookie-more-info')
-        this.$buttonsavepreferences = this.$el.find('#cookie-save-preferences')
-        this.$GAcheckbox = this.$el.find('#ccfw-ga-toggle')
-        this.$buttonmodalclose = this.$el.find('#ccfw-modal-close')
-        this.$body = $('body')
       },
-      setBannerDisplay: function () {
+      bannerDisplay: function () {
         if (utilities.checkForCookie(cookie_key_hide_banner) === true) {
-          this.$el.hide()
+          utilities.hideBanner()
         } else {
           this.$el.show()
         }
@@ -82,24 +92,54 @@
       bindEvents: function () {
         this.$buttonaccept.on('click', this.acceptAllButton.bind(this))
         this.$buttondecline.on('click', this.declineAllButton.bind(this))
-        this.$buttoninfo.on('click', this.viewMoreInfo.bind(this))
-        this.$buttonsavepreferences.on('click', this.saveCookiePreferences.bind(this))
-        this.$buttonmodalclose.on('click', this.closeModal.bind(this))
+        this.$buttoninfo.on('click', this.chooseCookieSettingsButton.bind(this))
       },
       acceptAllButton: function () {
         utilities.setCookie(cookie_key_hide_banner, 'true', 365)
         utilities.setCookie(cookie_key_ga_accept, 'true', 365)
-        this.hideBanner()
+        utilities.hideBanner()
       },
       declineAllButton: function() {
         utilities.setCookie(cookie_key_hide_banner, 'true', 365)
-        utilities.setCookie(cookie_key_ga_reject, 'true', 365)
-        this.hideBanner()
+
+        // GA - If present remove GA cookie, otherwise do nothing, default is GA off
+        if (utilities.checkForCookie(cookie_key_ga_accept)) {
+          utilities.deleteCookie(cookie_key_ga_accept)
+        }
+        utilities.hideBanner()
+      },
+      chooseCookieSettingsButton: function() {
+        utilities.showSettingsModal()
+      }
+    }
+
+    const settingsModal = {
+      init: function () {
+        this.cacheDom()
+        this.bindEvents()
+      },
+      cacheDom: function () {
+        this.$el = cacheMainElement.$el
+        this.$settingsModal = this.$el.find('#cookie-popup')
+        this.$buttonaccept = this.$settingsModal.find('#cookie-accept')
+        this.$buttondecline = this.$settingsModal.find('#cookie-decline')
+        this.$buttoninfo = this.$settingsModal.find('#cookie-more-info')
+        this.$buttonsavepreferences = this.$settingsModal.find('#cookie-save-preferences')
+        this.$GAcheckbox = this.$settingsModal.find('#ccfw-ga-toggle')
+        this.$buttonmodalclose = this.$settingsModal.find('#ccfw-modal-close')
+        this.$body = $('body')
+      },
+      bindEvents: function () {
+        this.$buttoninfo.on('click', this.viewMoreInfo.bind(this))
+        this.$buttonsavepreferences.on('click', this.saveCookiePreferences.bind(this))
+        this.$buttonmodalclose.on('click', this.modalDisplay.bind(this))
+      },
+      modalDisplay: function () {
+        utilities.hideSettingsModal()
       },
       viewMoreInfo: function () {
         this.$buttoninfo.attr('aria-expanded', 'true')
-        this.$popup.show()
-        this.$el.addClass("cookie-banner-open")
+        utilities.showSettingsModal()
         this.$body.addClass("ccfw-modal-open")
 
         /*Trap focus */
@@ -126,39 +166,29 @@
           }
         })
       },
-      closeModal: function () {
-        this.$buttoninfo.attr('aria-expanded', 'false')
-        this.$popup.hide()
-        this.$el.removeClass("cookie-banner-open")
-        this.$body.removeClass("ccfw-modal-open")
-        this.$el.removeClass("cookie-banner-open")
-        this.$popup.hide()
-      },
       saveCookiePreferences: function () {
         let analyticsCookiesTurnedOn = this.$GAcheckbox.prop('checked')
-
-        console.log(analyticsCookiesTurnedOn)
-
-        utilities.setCookie(cookie_key_hide_banner, 'true', 365)
 
         if (analyticsCookiesTurnedOn === true) {
           utilities.setCookie(cookie_key_ga_accept, 'true', 365)
         }
 
         if (analyticsCookiesTurnedOn === false) {
-          utilities.setCookie(cookie_key_ga_reject, 'true', 365)
+           // GA - If present remove GA cookie, otherwise do nothing, default is GA off
+          if (utilities.checkForCookie(cookie_key_ga_accept)) {
+            utilities.deleteCookie(cookie_key_ga_accept)
+          }
         }
 
-        this.closeModal()
-        this.hideBanner()
+        utilities.setCookie(cookie_key_hide_banner, 'true', 365)
+        utilities.hideBanner()
+        utilities.hideSettingsModal()
       },
-      hideBanner: function () {
-        this.$el.hide()
-        this.$el.removeClass("cookie-banner-open")
-      }
     }
 
+    cacheMainElement.init()
     utilities.init()
     banner.init()
+    settingsModal.init()
   })
 })(jQuery)


### PR DESCRIPTION
Main changes here include
* Reduce complexity so that on first load no cookies are loaded. And GA is blocked
* Remove the complexity around also blocking GTM as it doesn't have any tracking cookie.
* Remove some of the old JS that is no longer needed bc of the changes above.
* Leverage the WP wp_head hook to put in optout JS on page load.

More changes to follow, introducing CSS, and a WP option to add GA ID code.