### PR TITLE
Update save text

### DIFF
--- a/components/Banner/partials/partial-banner.php
+++ b/components/Banner/partials/partial-banner.php
@@ -212,7 +212,7 @@ $bannerTitle = !empty($options['banner_title']) ? $options['banner_title'] : 'Ar
             </details>
 
             <button id="cookie-save-preferences" class="ccfw-banner__button">
-                <?php _e('Save my choice', 'cookie-compliance-for-wordpress'); ?>
+                <?php _e('Save cookie preferences', 'cookie-compliance-for-wordpress'); ?>
             </button>
         </div>
     </div>

--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,53 @@
+=== NHS Blocks ===
+Contributors: brown-a2, bnewing
+Tags: GDPR, PECR, cookies
+Plugin Name:: Cookie Compliance for WordPress
+Plugin URI: (we might need to set up a page, maybe in our JOTW Jekyll site?)
+Requires at least: 5.3
+Tested up to: 5.5
+Stable tag: (needs adding)
+Requires PHP: 5.6
+License: GPLv3 or later (do we want to change this?)
+License URI: https://www.gnu.org/licenses/gpl-3.0.html (might need updating based on above)
+
+A GDPR/PECR compliant cookie banner, that allows users to toggle cookies.
+
+== Description ==
+
+(Describe the plugin)
+
+== Installation ==
+
+This section describes how to install the plugin and get it working.
+
+1. (Describe step one)
+2. (Describe step two)
+3. (Describe step three)
+
+== Frequently Asked Questions ==
+
+= Question =
+
+Answer
+
+== Screenshots ==
+1. (Describe feature)
+2. (Describe feature)
+
+== Changelog ==
+
+= (number) =
+ * (details of change)
+ * (details of change)
+ * (details of change))
+
+
+= (number) =
+ * (details of change)
+ * (details of change)
+ * (details of change))
+
+
+== Development / Contributing ==
+
+Contributions to development of this work are welcome at [our GitHub repository](https://github.com/ministryofjustice/cookie-compliance-for-wordpress "Cookie Compliance for WordPress").

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
-=== NHS Blocks ===
-Contributors: brown-a2, bnewing
+=== Cookie compliance for WordPress ===
+Contributors:
 Tags: GDPR, PECR, cookies
 Plugin Name:: Cookie Compliance for WordPress
 Plugin URI: (we might need to set up a page, maybe in our JOTW Jekyll site?)


### PR DESCRIPTION
The save button text needed to be made more descriptive, following feedback from a DAC WCAG audit. This makes that change. 

It also adds in a `readme.txt` template for if we want to put it into the WordPress plugin store at some point (I had it locally from having worked on it before so thought I'd add it up with this, but if it should be a separate PR let me know and I'll separate it out!).