### PR TITLE
Add data attribute to block google from displaying cookie banner text

### DIFF
--- a/components/Banner/partials/partial-banner.php
+++ b/components/Banner/partials/partial-banner.php
@@ -29,7 +29,7 @@ $bannerTitle = !empty($options['banner_title']) ? $options['banner_title'] : 'Ar
     </svg>
     <p class="ccfw-settings-button__text"><span class="visually-hidden">Cookie</span>Settings</p>
 </button>
-<div id="ccfw-page-banner">
+<div id="ccfw-page-banner" data-nosnippet="true">
     <div class="ccfw-banner">
         <div class="ccfw-banner__intro">
             <?php _e('<h2 class="ccfw-banner__heading">' . esc_attr($bannerTitle) . '</h2>', 'cookie-compliance-for-wordpress'); ?>


### PR DESCRIPTION
At the moment, in some cases, google is displaying cookie content instead of site content in the snippet displayed in search results. This adds a data attribute which we think will stop it from indexing the cookie banner content.