### PR TITLE
Remove cookies on non-www domain too

### DIFF
--- a/components/Banner/Banner.php
+++ b/components/Banner/Banner.php
@@ -76,8 +76,7 @@ class Banner
                     // Also remove cookies that start with domains without www
                     if(document.domain.includes("www.")){
                         const nonWwwDomain = document.domain.replace("www.", ".")
-                        document.cookie = ccfwCookies[ccfwCookie] + '=; Path=/; domain=.'+ nonWwwDomain
-                    +'; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+                        document.cookie = ccfwCookies[ccfwCookie] + '=; Path=/; domain=.' + nonWwwDomain + '; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
                     }
                 };
             };

--- a/components/Banner/Banner.php
+++ b/components/Banner/Banner.php
@@ -72,6 +72,11 @@ class Banner
                 for (var ccfwCookie = 0; ccfwCookie < ccfwCookiesArrayLength; ccfwCookie++) {
                     document.cookie = ccfwCookies[ccfwCookie] + '=; Path=/; domain=.'+ document.domain
                     +'; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+
+                    // Also remove cookies that start with domains without www
+                    var nonWwwDomain = document.domain.slide(3);
+                    document.cookie = ccfwCookies[ccfwCookie] + '=; Path=/; domain=.'+ nonWwwDomain
+                    +'; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
                 };
             };
         </script>

--- a/components/Banner/Banner.php
+++ b/components/Banner/Banner.php
@@ -74,9 +74,11 @@ class Banner
                     +'; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
 
                     // Also remove cookies that start with domains without www
-                    var nonWwwDomain = document.domain.slide(3);
-                    document.cookie = ccfwCookies[ccfwCookie] + '=; Path=/; domain=.'+ nonWwwDomain
+                    if(document.domain.includes("www.")){
+                        const nonWwwDomain = document.domain.replace("www.", ".")
+                        document.cookie = ccfwCookies[ccfwCookie] + '=; Path=/; domain=.'+ nonWwwDomain
                     +'; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+                    }
                 };
             };
         </script>

--- a/cookie-compliance-for-wordpress.php
+++ b/cookie-compliance-for-wordpress.php
@@ -8,7 +8,7 @@
  * Plugin Name:       Cookie Compliance for WordPress
  * Plugin URI:        https://github.com/ministryofjustice/cookie-compliance-for-wordpress
  * Description:       Presents users with cookie compliance field when they first visit the website.
- * Version:           2.0.3
+ * Version:           2.0.4
  * Requires at least: 5.2.3
  * Requires PHP:      7.0
  * Author:            Ministry of Justice

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cookie-compliance-for-wordpress",
-    "version": "2.0.3",
+    "version": "2.0.4",
     "engines": {
         "node": "11.10.0",
         "npm": "6.13.6"


### PR DESCRIPTION
There was a bug where on some sites, the GA cookies were being set on '.domainName' rather than 'www.domainName' - which meant that our JS to remove them wasn't working. This adds in some code that will remove both types of cookie.