### PR TITLE
Fix wwwDomain not catching domain

### DIFF
--- a/components/Banner/Banner.php
+++ b/components/Banner/Banner.php
@@ -75,7 +75,7 @@ class Banner
 
                     // Also remove cookies that start with domains without www
                     if(document.domain.includes("www.")){
-                        const nonWwwDomain = document.domain.replace("www.", ".")
+                        const nonWwwDomain = document.domain.replace("www.", "")
                         document.cookie = ccfwCookies[ccfwCookie] + '=; Path=/; domain=.' + nonWwwDomain + '; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
                     }
                 };

--- a/cookie-compliance-for-wordpress.php
+++ b/cookie-compliance-for-wordpress.php
@@ -8,7 +8,7 @@
  * Plugin Name:       Cookie Compliance for WordPress
  * Plugin URI:        https://github.com/ministryofjustice/cookie-compliance-for-wordpress
  * Description:       Presents users with cookie compliance field when they first visit the website.
- * Version:           2.0.5
+ * Version:           2.0.6
  * Requires at least: 5.2.3
  * Requires PHP:      7.0
  * Author:            Ministry of Justice

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cookie-compliance-for-wordpress",
-    "version": "2.0.5",
+    "version": "2.0.6",
     "engines": {
         "node": "12.18.3",
         "npm": "7.5.2"


### PR DESCRIPTION
We added in a fix to the GA bug issue, where www-based domain cookies weren't being turned on. An extra full stop was being added in though, which prevented the right domain from being picked up. This corrects that.