### PR TITLE
CDPTKAN-113 Use secure flag for `ccfw_gtm_id` cookie when https.

### DIFF
--- a/components/General/General.php
+++ b/components/General/General.php
@@ -60,7 +60,8 @@ class General
             $gtm_id = $_COOKIE['ccfw_gtm_id'] ?? null;
 
             if (!$gtm_id || ($this->googleTagManagerID !== $gtm_id)) {
-                setcookie('ccfw_gtm_id', $this->googleTagManagerID, time() + 31556926);
+                $secure = apply_filters('ccfw_set_secure_cookie', is_ssl());
+                setcookie('ccfw_gtm_id', $this->googleTagManagerID, time() + 31556926, '', '', $secure);
                 $_COOKIE['ccfw_gtm_id'] = $this->googleTagManagerID;
             }
         }


### PR DESCRIPTION
Hi folks, a pen test on the Justice identified that the `ccfw_gtm_id` cookie was being set without a secure flag.

This PR addresses that issue by using the WordPress function `is_ssl`.

I have given thought to backward compatibility and tried to avoid introducing a breaking change.

I don't fully understand all of the environments where this plugin is used, so for that reason I have allowed for the secure flag to be filtered in cases where is_ssl is not accurate.

Hopefully I can get a review and release. Looking forward to feedback :) 